### PR TITLE
Use Nix flake to Build, Develop, & WIP: run integration test cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ In other words, your grandmother will be able to somewhat privately open a bunch
 * `.unwraps()`s EVERYWHERE!
 * I swear I knew about a few more but can't remember right now :D
 
+## Nix Build
+
+You need to have [Nix](https://nixos.org/download.html). That's it.
+
+0. `nix build` to pull all dependencies and build the crate.
+1. `nix run` to run the debug target with no features or `nix develop` for a shell with tooling already installed.
+
 ## Usage
 
 0. You need Rust version 1.48 or higher to compile this.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In other words, your grandmother will be able to somewhat privately open a bunch
 * `.unwraps()`s EVERYWHERE!
 * I swear I knew about a few more but can't remember right now :D
 
-## Nix Build
+## Nix
 
 You need to have [Nix](https://nixos.org/download.html). That's it.
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "naersk": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -65,9 +50,24 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "naersk": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -18,6 +33,27 @@
         "type": "github"
       }
     },
+    "nix-bitcoin": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgsUnstable": "nixpkgsUnstable"
+      },
+      "locked": {
+        "lastModified": 1658671490,
+        "narHash": "sha256-CCOMiMqAhKEmTwggTkwyNSiCdGS/IOfJTPd1u+47ZrE=",
+        "owner": "fort-nix",
+        "repo": "nix-bitcoin",
+        "rev": "fbbaaa7a29dfb973ea13e698f4116941fa4c69d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fort-nix",
+        "ref": "release",
+        "repo": "nix-bitcoin",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1660524483,
@@ -32,7 +68,39 @@
         "type": "indirect"
       }
     },
+    "nixpkgsUnstable": {
+      "locked": {
+        "lastModified": 1658430343,
+        "narHash": "sha256-cZ7dw+dyHELMnnMQvCE9HTJ4liqwpsIt2VFbnC+GNNk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e2b34f0f11ed8ad83d9ec9c14260192c3bcccb0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1658406394,
+        "narHash": "sha256-hgibXbbmxucpVJy9eOXKn7HxQtVkpeZ8euSnWl6c9Mk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c93e5ab157b45adbb6165bd85a9d8f67e49ff31d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1660524483,
         "narHash": "sha256-Rb/AZ5FErbML2f6+XxJTo+BbDMVtiTVGWML4pOiwBSE=",
@@ -51,7 +119,8 @@
     "root": {
       "inputs": {
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
+        "nix-bitcoin": "nix-bitcoin",
+        "nixpkgs": "nixpkgs_3",
         "utils": "utils"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,76 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1659610603,
+        "narHash": "sha256-LYgASYSPYo7O71WfeUOaEUzYfzuXm8c8eavJcel+pfI=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "c6a45e4277fa58abd524681466d3450f896dc094",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1660524483,
+        "narHash": "sha256-Rb/AZ5FErbML2f6+XxJTo+BbDMVtiTVGWML4pOiwBSE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "680f04a9930fa0b9572abda5a9429cb2b1c77655",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1660524483,
+        "narHash": "sha256-Rb/AZ5FErbML2f6+XxJTo+BbDMVtiTVGWML4pOiwBSE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "680f04a9930fa0b9572abda5a9429cb2b1c77655",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -38,15 +38,84 @@
               );
           };
 
+          # nixosModules.default = { config, pkgs, ... }: {
+          #   imports = [ nix-bitcoin.nixosModules ];
+
+          #   options = {
+          #     nix-bitcoin.userVersionLockedPkgs = mkOption {
+          #       type = types.bool;
+          #       default = false;
+          #       description = ''
+          #         Use the nixpkgs version locked by this flake for `nix-bitcoin.pkgs`.
+          #         Only relevant if you are using a nixpkgs version for evaluating your system
+          #         that differs from the one that is locked by this flake (via input `nixpkgs`).
+          #         If this is the case, enabling this option may result in a more stable system
+          #         because the nix-bitcoin services use the exact pkgs versions that are tested
+          #         by nix-bitcoin.
+          #         The downsides are increased evaluation times and increased system
+          #         closure size.
+          #         If `false`, the default system pkgs are used.
+          #       ''
+          #     }
+          #   }
+          # }
+          bitcoin = {
+              nixosConfigurations.mynode = nix-bitcoin.inputs.nixpkgs.lib.nixosSystem {
+                system = "x86_64-linux";
+                modules = [
+                  nix-bitcoin.nixosModules.default
+
+                  # Optional:
+                  # Import the secure-node preset, an opinionated config to enhance security
+                  # and privacy.
+                  #
+                  # "${nix-bitcoin}/modules/presets/secure-node.nix"
+
+                  {
+                    # Automatically generate all secrets required by services.
+                    # The secrets are stored in /etc/nix-bitcoin-secrets
+                    nix-bitcoin.generateSecrets = true;
+
+                    # Enable services.
+                    # See ../configuration.nix for all available features.
+                    services.bitcoind.enable = true;
+                    services.bitcoind.regtest = true;
+
+                    # When using nix-bitcoin as part of a larger NixOS configuration, set the following to enable
+                    # interactive access to nix-bitcoin features (like bitcoin-cli) for your system's main user
+                    nix-bitcoin.operator = {
+                      enable = true;
+                      name = "main"; # Set this to your system's main user
+                    };
+
+                    # The system's main unprivileged user. This setting is usually part of your
+                    # existing NixOS configuration.
+                    users.users.main = {
+                      isNormalUser = true;
+                      password = "a";
+                    };
+
+                    # If you use a custom nixpkgs version for evaluating your system
+                    # (instead of `nix-bitcoin.inputs.nixpkgs` like in this example),
+                    # consider setting `useVersionLockedPkgs = true` to use the exact pkgs
+                    # versions for nix-bitcoin services that are tested by nix-bitcoin.
+                    # The downsides are increased evaluation times and increased system
+                    # closure size.
+                    #
+                    # nix-bitcoin.useVersionLockedPkgs = true;
+                  }
+                ];
+              };
+          };
+
           docker = let
             loin = self.packages.${system}.default;
+            bitcoin = self.packages.${system}.bitcoin;
           in pkgs.dockerTools.buildLayeredImage {
             name = "loin-integration";
-            tag = loin.version;
-            contents = [ loin nix-bitcoin ];
+            contents = [ loin ];
 
             config = {
-              Cmd = ["echo 'hi from docker'"];
               WorkingDir = "/";
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       in {
         packages = {
           # For `nix build` & `nix run`:
-          default= naersk'.buildPackage {
+          default = naersk'.buildPackage {
             src = ./.;
           };
 
@@ -32,6 +32,19 @@
                   darwin.apple_sdk.frameworks.Security pkgconfig openssl
                 ]
               );
+          };
+
+          docker = let
+            loin = self.packages.${system}.default;
+          in pkgs.dockerTools.buildLayeredImage {
+            name = loin.pname;
+            tag = loin.version;
+            contents = [ loin ];
+
+            config = {
+              Cmd = [ "cargo run" ];
+              WorkingDir = "/";
+            }
           };
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,11 @@
   inputs = {
     utils.url = "github:numtide/flake-utils";
     naersk.url = "github:nix-community/naersk";
+    nix-bitcoin.url = "github:fort-nix/nix-bitcoin/release";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = { self, utils, naersk, nixpkgs }:
+  outputs = { self, utils, naersk, nix-bitcoin, nixpkgs }:
     utils.lib.eachDefaultSystem (system:
       let
         pkgs = (import nixpkgs) {
@@ -28,7 +29,7 @@
 
           # For `nix develop`:
           devShells.default = pkgs.mkShell {
-            nativeBuildInputs = with pkgs; [ rustc cargo ] ++ (
+            nativeBuildInputs = with pkgs; [ rustc cargo  ] ++ (
                 lib.optional stdenv.isDarwin [
                   libiconv
                   # For `tonic_lnd`
@@ -42,7 +43,7 @@
           in pkgs.dockerTools.buildLayeredImage {
             name = "loin-integration";
             tag = loin.version;
-            contents = [ loin ];
+            contents = [ loin nix-bitcoin ];
 
             config = {
               Cmd = ["echo 'hi from docker'"];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "Build L[ightning Payj]oin and its Development Environment";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, flake-utils, naersk, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = (import nixpkgs) {
+          inherit system;
+        };
+
+        naersk' = pkgs.callPackage naersk {};
+
+      in rec {
+        # For `nix build` & `nix run`:
+        defaultPackage = naersk'.buildPackage {
+          src = ./.;
+        };
+
+        # For `nix develop`:
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [ rustc cargo ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Build L[ightning Payj]oin and its Development Environment";
+  description = "Build L[ightning PayJ]oin and its Development Environment";
 
   inputs = {
     utils.url = "github:numtide/flake-utils";
@@ -15,11 +15,14 @@
         };
 
         naersk' = pkgs.callPackage naersk {};
-
+        version = builtins.substring 0 8 self.lastModifiedDate;
       in {
         packages = {
           # For `nix build` & `nix run`:
           default = naersk'.buildPackage {
+            pname = "loin";
+            inherit version;
+
             src = ./.;
           };
 
@@ -37,14 +40,14 @@
           docker = let
             loin = self.packages.${system}.default;
           in pkgs.dockerTools.buildLayeredImage {
-            name = loin.pname;
+            name = "loin-integration";
             tag = loin.version;
             contents = [ loin ];
 
             config = {
-              Cmd = [ "cargo run" ];
+              Cmd = ["echo 'hi from docker'"];
               WorkingDir = "/";
-            }
+            };
           };
         };
       }

--- a/packages.nix
+++ b/packages.nix
@@ -1,0 +1,25 @@
+let
+# Pinning to revision e0361a947ed3eb692e43786f78e86075395ef3af for cln v0.11.1 
+# and lnd v0.15.0-beta.
+rev = "e0361a947ed3eb692e43786f78e86075395ef3af";
+nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+pkgs = import nixpkgs {};
+
+# Override priority for bitcoin as /bin/bitcoin_test will
+# confilict with /bin/bitcoin_test from elementsd.
+bitcoin = (pkgs.bitcoin.overrideAttrs (attrs: {
+    meta = attrs.meta or {} // {
+        priority = 0;
+    };
+}));
+
+in with pkgs;
+{
+    execs = {
+        bitcoin = bitcoin;
+        lnd = lnd;
+        mermaid = nodePackages.mermaid-cli;
+    };
+    testpkgs = [ rustc cargo bitcoin lnd];
+    devpkgs = [ bitcoin lnd docker-compose jq nodePackages.mermaid-cli ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,23 @@
+let
+    loin-pkgs = import ./packages.nix;
+in
+{ pkgs ? (import <nixpkgs> {})}:
+let
+    execs = loin-pkgs.execs;
+in with pkgs;
+stdenv.mkDerivation rec {
+    name = "loin-dev-env";
+    nativeBuildInputs = [openssl];
+    buildInputs = [ loin-pkgs.devpkgs ];
+    
+    shellHook = ''
+    alias bitcoind='${execs.bitcoin}/bin/bitcoind'
+    alias bitcoin-cli='${execs.bitcoin}/bin/bitcoin-cli'
+    alias lnd='${execs.lnd}/bin/lnd'
+    alias lncli='${execs.lnd}/bin/lncli'
+
+    . ./startup_regtest.sh
+    setup_alias
+    '';
+}
+

--- a/startup_regtest.sh
+++ b/startup_regtest.sh
@@ -1,0 +1,374 @@
+#!/bin/bash
+
+start_docker_env() {
+  docker-compose -f .ci/docker/docker-compose.yml up -d --remove-orphans
+}
+
+stop_docker_env() {
+  docker-compose -f .ci/docker/docker-compose.yml down
+}
+
+stop_nodes() {
+  if [ -z "$2" ]; then
+    network=regtest
+  else
+    network="$2"
+  fi
+  if [ -n "$LN_NODES" ]; then
+    for i in $(seq $LN_NODES); do
+      test ! -f "/tmp/l$i-$network/lightningd-$network.pid" ||
+        (
+          node_pid=$(cat "/tmp/l$i-$network/lightningd-$network.pid")
+          echo "stopping node $i with pid $node_pid"
+          kill $node_pid
+          rm "/tmp/l$i-$network/lightningd-$network.pid"
+          unset node_pid
+        )
+      echo "$(lncli-1 stop)"
+      echo "$(lncli-2 stop)"
+      unalias "l$i-cli"
+      unalias "l$i-log"
+    done
+  fi
+}
+
+remove_nodes() {
+  stop_nodes
+  if [ -z "$1" ]; then
+    network=regtest
+  else
+    network="$1"
+  fi
+  if [ -n "$LN_NODES" ]; then
+    for i in $(seq $LN_NODES); do
+      LN_DIR="/tmp/l$i-$network"
+      rm -rf "/tmp/lnd-regtest-$i"
+      if [ -d $LN_DIR ]; then
+        echo "removing node from $LN_DIR"
+        rm -rf $LN_DIR
+      fi
+    done
+  fi
+  unset LN_DIR
+}
+
+start_nodes_lnd() {
+  LND='lnd'
+  if [ -z "$1" ]; then
+    node_count=2
+  else
+    node_count=$1
+  fi
+  LND_NODES=$node_count
+  for i in $(seq $node_count); do
+    rpcport=$((10101 + i * 100))
+    listenport=$((10102 + i * 100))
+    mkdir -p "/tmp/lnd-regtest-$i/data"
+    touch "/tmp/lnd-regtest-$i/data/lnd.conf"
+    # Start the lightning nodes
+    lnd --datadir=/tmp/lnd-regtest-$i/data \
+    --bitcoin.active --bitcoin.regtest --bitcoin.node=bitcoind \
+    --bitcoind.rpchost=localhost:18443 --bitcoind.rpcuser=admin1 --bitcoind.rpcpass=123 \
+    --bitcoind.zmqpubrawblock=tcp://127.0.0.1:29000 --bitcoind.zmqpubrawtx=tcp://127.0.0.1:29001 \
+    --noseedbackup --tlskeypath=/tmp/lnd-regtest-$i/tls.key --tlscertpath=/tmp/lnd-regtest-$i/tls.cert \
+    --rpclisten=0.0.0.0:$rpcport --norest \
+    --logdir=/tmp/lnd-regtest-$i/logs \
+    --externalip=127.0.0.1:$listenport \
+    --listen=0.0.0.0:$listenport \
+    --protocol.wumbo-channels \
+    --configfile=/tmp/lnd-regtest-$1/lnd.conf > /dev/null 2>&1 &
+    # shellcheck disable=SC2139 disable=SC2086
+    alias lncli-$i="$LNCLI --lnddir=/tmp/lnd-regtest-$i --network regtest --rpcserver=localhost:$rpcport"
+    alias lnd-$i-logs="tail -f /tmp/l$i-$network/log"
+  done
+}
+
+start_peerswap_lnd() {
+  if [ -z "$1" ]; then
+      node_count=2
+    else
+      node_count=$1
+  fi
+    for i in $(seq $node_count); do
+      lndrpcport=$((10101 + i * 100))
+      listenport=$((42069 + i * 100))
+      lndpath="/tmp/lnd-regtest-$i"
+      mkdir -p "/tmp/lnd-peerswap-$i/"
+      cat <<-EOF >"/tmp/lnd-peerswap-$i/config"
+network=regtest
+host=localhost:$listenport
+datadir=/tmp/lnd-peerswap-$i/
+lnd.host=localhost:$lndrpcport
+lnd.tlscertpath=$lndpath/tls.cert
+lnd.macaroonpath=$lndpath/data/chain/bitcoin/regtest/admin.macaroon
+bitcoinswaps=true
+liquid.rpcuser=admin1
+liquid.rpcpass=123 
+liquid.rpchost=http://127.0.0.1
+liquid.rpcport=18884
+liquid.rpcwallet=swaplnd-$i
+accept_all_peers=true
+EOF
+  
+    ./out/peerswapd "--configfile=/tmp/lnd-peerswap-$i/config" > /dev/null 2>&1 &
+
+    done
+}
+start_nodes() {
+  LIGHTNINGD='lightningd'
+  if [ -z "$1" ]; then
+    node_count=2
+  else
+    node_count=$1
+  fi
+  if [ "$node_count" -gt 100 ]; then
+    node_count=100
+  fi
+  if [ -z "$2" ]; then
+    network=regtest
+  else
+    network=$2
+  fi
+  LN_NODES=$node_count
+  for i in $(seq $node_count); do
+    socket=$((7070 + i * 101))
+    liquidrpcPort=18884
+    mkdir -p "/tmp/l$i-$network"
+    # Node config
+    cat <<-EOF >"/tmp/l$i-$network/config"
+network=$network
+log-level=debug
+log-file=/tmp/l$i-$network/log
+addr=127.0.0.1:$socket
+bitcoin-rpcuser=admin1
+bitcoin-rpcpassword=123
+bitcoin-rpcconnect=127.0.0.1
+bitcoin-rpcport=18443
+large-channels
+EOF
+    # If we've configured to use developer, add dev options
+    if $LIGHTNINGD --help | grep -q dev-fast-gossip; then
+      cat <<-EOF >>"/tmp/l$i-$network/config"
+dev-fast-gossip
+dev-bitcoind-poll=5
+experimental-dual-fund
+funder-policy=match
+funder-policy-mod=100
+funder-min-their-funding=10000
+funder-per-channel-max=100000
+funder-fuzz-percent=0
+EOF
+    fi
+    PWD=$(pwd)
+    # Start the lightning nodes
+    test -f "/tmp/l$i-$network/lightningd-$network.pid" ||
+      "$LIGHTNINGD" "--lightning-dir=/tmp/l$i-$network" --daemon \
+        "--plugin=$PWD/out/peerswap-plugin" \
+        --peerswap-elementsd-rpchost=http://127.0.0.1 \
+        --peerswap-elementsd-rpcport=$liquidrpcPort \
+        --peerswap-elementsd-rpcuser=admin1 \
+        --peerswap-elementsd-rpcpassword=123 \
+        --peerswap-elementsd-rpcwallet=swap-$i \
+        --peerswap-policy-path=/tmp/l$i-$network/policy.conf
+    # shellcheck disable=SC2139 disable=SC2086
+    alias l$i-cli="$LCLI --lightning-dir=/tmp/l$i-$network"
+    # shellcheck disable=SC2139 disable=SC2086
+    alias l$i-log="less /tmp/l$i-$network/log"
+    alias l$i-follow="tail -f /tmp/l$i-$network/log"
+    alias l$i-followf="tail -f /tmp/l$i-$network/log | grep peerswap"
+  done
+  # set peer allowlist in policy
+  for i in $(seq $node_count); do
+    POLICY="/tmp/l$i-$network/policy.conf"
+    if [ ! -f "$POLICY" ]; then
+      for j in $(seq $node_count); do
+        cat <<-EOF >> $POLICY
+allowlisted_peers=$($LCLI --lightning-dir=/tmp/l$j-$network getinfo | jq -r .id)
+EOF
+      done
+      echo "accept_all_peers=1" >> $POLICY
+    fi
+  done
+  # Give a hint.
+  echo "Commands: "
+  for i in $(seq $node_count); do
+    echo "	l$i-cli, l$i-log, l$i-follow, l$i-followf"
+  done
+}
+remove_swaps() {
+  rm /tmp/l1-regtest/regtest/swaps/swaps
+  rm /tmp/l2-regtest/regtest/swaps/swaps
+}
+setup_alias() {
+  node_count=2
+  network=regtest
+
+  LN_NODES=$node_count
+
+  LCLI='lightning-cli'
+  LNCLI='lncli'
+  for i in $(seq $node_count); do
+    # shellcheck disable=SC2139 disable=SC2086
+    alias l$i-cli="$LCLI --lightning-dir=/tmp/l$i-$network"
+    # shellcheck disable=SC2139 disable=SC2086
+    alias l$i-log="less /tmp/l$i-$network/log"
+    alias l$i-follow="tail -f /tmp/l$i-$network/log"
+ #    alias l$i-followf="tail -f /tmp/l$i-$network/log | grep peerswap"
+  done
+  for i in $(seq 3); do
+    rpcport=$((10101 + i * 100))
+    alias lncli-$i="$LNCLI --lnddir=/tmp/lnd-regtest-$i --network regtest --rpcserver=localhost:$rpcport"
+    alias lnd-$i-logs="tail -f /tmp/lnd-regtest-$i/logs/bitcoin/regtest/lnd.log"
+  done
+  # Give a hint.
+  echo "Commands: "
+  for i in $(seq $node_count); do
+    echo "	l$i-cli, l$i-log, l$i-follow, l$i-followf, lncli-$i, lnd-$i-logs"
+  done
+
+  alias bt-cli='bitcoin-cli -regtest -rpcuser=polaruser -rpcpassword=polarpassword -rpcconnect=127.0.0.1 -rpcport=18443'
+  # alias et-cli='elements-cli -rpcuser=admin1 -rpcpassword=123 -rpcconnect=127.0.0.1 -rpcport=18884'
+  # alias et-cli2='elements-cli -rpcuser=admin1 -rpcpassword=123 -rpcconnect=127.0.0.1 -rpcport=18885'
+
+}
+
+connect_nodes() {
+  # connect clightning nodes
+  L2_PORT=$(l2-cli getinfo | jq .binding[0].port)
+
+  L2_PUBKEY=$(l2-cli getinfo | jq -r .id)
+
+  L2_CONNECT="$L2_PUBKEY@127.0.0.1:$L2_PORT"
+
+  echo "$(l1-cli connect $L2_CONNECT)"
+  # connect lnd ndoes
+  LND_URI1=$(lncli-1 getinfo | jq -r .uris[0])
+  LND_URI2=$(lncli-2 getinfo | jq -r .uris[0])
+
+  echo "$(lncli-1 connect $LND_URI2)"
+  echo "$(l1-cli connect $LND_URI1)"
+  echo "$(l1-cli connect $LND_URI2)"
+  echo "$(l2-cli connect $LND_URI1)"
+  echo "$(l2-cli connect $LND_URI2)"
+}
+rebuild() {
+  make build
+  restart
+}
+restart() {
+  stop_nodes "$1" regtest
+  start_nodes "$nodes" regtest
+  start_nodes_lnd "$nodes"
+}
+
+l1-pay() {
+  LABEL=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13)
+  BOLT11=$(l1-cli invoice $1 $LABEL "foo" | jq -r .bolt11)
+  echo $BOLT11
+  RES=$(l2-cli pay $BOLT11)
+  echo $RES
+}
+l2-pay() {
+  LABEL=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13)
+  BOLT11=$(l2-cli invoice $1 $LABEL "foo" | jq -r .bolt11)
+  RES=$(l1-cli pay $BOLT11)
+  echo $RES
+}
+
+setup_channel() {
+  connect_nodes
+  L2_PUBKEY=$(l2-cli getinfo | jq -r .'id')
+  echo $(l1-cli fundchannel $L2_PUBKEY 10000000)
+  echo $(generate 12)
+}
+
+setup_channel_lnd() {
+  connect_nodes
+  L2_PUBKEY=$(lncli-2 getinfo | jq -r .'identity_pubkey')
+  echo $(lncli-1 openchannel $L2_PUBKEY 1000000)
+  echo $(generate 12)
+}
+
+setup_channel_lnd_cl() {
+  connect_nodes
+  L1_PUBKEY=$(l1-cli getinfo | jq -r .'id')
+  echo $(lncli-1 openchannel $L1_PUBKEY 1000000)
+  echo $(generate 12)
+}
+
+fund_node() {
+  L1_ADDR=$(l1-cli newaddr | jq .'bech32')
+  L1_ADDR=$(sed -e 's/^"//' -e 's/"$//' <<<"$L1_ADDR")
+  echo $(bt-cli generatetoaddress 1 $L1_ADDR)
+  echo $(generate 100)
+}
+
+fund_node_2() {
+  L1_ADDR=$(l2-cli newaddr | jq .'bech32')
+  L1_ADDR=$(sed -e 's/^"//' -e 's/"$//' <<<"$L1_ADDR")
+  echo $(bt-cli generatetoaddress 1 $L1_ADDR)
+  echo $(generate 100)
+}
+
+fund_node_lnd() {
+  L1_ADDR=$(lncli-1 newaddress p2wkh | jq -r .'address')
+  echo $(bt-cli generatetoaddress 1 $L1_ADDR)
+  echo $(generate 100)
+}
+
+fund_node_lnd_2() {
+  L1_ADDR=$(lncli-2 newaddress p2wkh | jq -r .'address')
+  echo $(bt-cli generatetoaddress 1 $L1_ADDR)
+  echo $(generate 100)
+}
+
+
+
+fund_nodes_l() {
+  echo $(l1-cli dev-liquid-faucet)
+  echo $(l2-cli dev-liquid-faucet)
+}
+
+l_generate() {
+  if [ -z "$1" ]; then
+    block_count=1
+  else
+    block_count=$1
+  fi
+  res=$(et-cli generatetoaddress $block_count ert1qfkht0df45q00kzyayagw6vqhfhe8ve7z7wecm0xsrkgmyulewlzqumq3ep)
+  echo $res
+}
+
+generate() {
+  if [ -z "$1" ]; then
+    block_count=1
+  else
+    block_count=$1
+  fi
+  res=$(bt-cli generatetoaddress $block_count 2NDsRVXmnw3LFZ12rTorcKrBiAvX54LkTn1)
+  echo $res
+}
+
+reset_dev_env() {
+  remove_nodes
+  stop_docker_env
+  rm -rf .ci/docker/config/regtest
+  rm -rf .ci/docker/liquid-config/liquidregtest
+  rm -rf .ci/docker/liquid-config2/liquidregtest
+}
+
+start_dev_env() {
+  start_docker_env
+  rebuild
+}
+
+stop_peerswap_lnd() {
+  ./out/pscli "--rpcserver=localhost:42169" stop
+  ./out/pscli "--rpcserver=localhost:42269" stop
+}
+
+rebuild_peerswap_lnd() {
+  stop_peerswap_lnd
+  make build
+  start_peerswap_lnd
+}


### PR DESCRIPTION
The easiest way to do this seems to be to get all the binaries sorted from nix in a nix-shell instead of flake and have the shellHooks set up the binaries. I think it's possible to do with flake and `nix shell` and eventually with the VM but not quite yet.

This change sets up a default package that runs the server with `nix build` and `nix run`. It also sets up a dev environment for mac or linux with `nix develop`

The docker package is intended to run integration tests on a containerized lightning cluster. I think it makes sense to run integration tests out of a docker container because [NixOS VMs don't run on MacOS yet](https://github.com/NixOS/nixpkgs/issues/108984)a