### PR TITLE
Split Modules from main function

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -70,5 +70,5 @@ where
         }
     };
 
-    Ok(Some(ScheduledPayJoin { wallet_amount, channels, fee_rate }))
+    Ok(Some(ScheduledPayJoin::new(wallet_amount, channels, fee_rate)))
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 use std::fmt;
 use std::num::ParseIntError;
 
-use crate::{ScheduledChannel, ScheduledPayJoin};
+use crate::scheduler::{ScheduledChannel, ScheduledPayJoin};
 
 /// CLI argument errors.
 #[derive(Debug)]

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,108 @@
+use std::net::SocketAddr;
+
+use bip78::receiver::*;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
+
+use crate::scheduler::{ScheduledPayJoin, Scheduler};
+
+#[cfg(not(feature = "test_paths"))]
+const STATIC_DIR: &str = "/usr/share/loin/static";
+
+#[cfg(feature = "test_paths")]
+const STATIC_DIR: &str = "static";
+
+/// Serve requests to Schedule and execute PayJoins with given options.
+pub async fn serve(sched: Scheduler, bind_addr: SocketAddr) -> Result<(), hyper::Error> {
+    let new_service = make_service_fn(move |_| {
+        let sched = sched.clone();
+        async move {
+            let handler = move |req| handle_web_req(sched.clone(), req);
+            Ok::<_, hyper::Error>(service_fn(handler))
+        }
+    });
+
+    let server = Server::bind(&bind_addr).serve(new_service);
+    println!("Listening on: http://{}", bind_addr);
+    server.await
+}
+
+async fn handle_web_req(
+    scheduler: Scheduler,
+    req: Request<Body>,
+) -> Result<Response<Body>, hyper::Error> {
+    use std::path::Path;
+
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/pj") => {
+            let index =
+                std::fs::read(Path::new(STATIC_DIR).join("index.html")).expect("can't open index");
+            Ok(Response::new(Body::from(index)))
+        }
+
+        (&Method::GET, path) if path.starts_with("/pj/static/") => {
+            let directory_traversal_vulnerable_path = &path[("/pj/static/".len())..];
+            let file =
+                std::fs::read(Path::new(STATIC_DIR).join(directory_traversal_vulnerable_path))
+                    .expect("can't open static file");
+            Ok(Response::new(Body::from(file)))
+        }
+
+        (&Method::POST, "/pj") => {
+            dbg!(req.uri().query());
+
+            let headers = Headers(req.headers().to_owned());
+            let query = {
+                let uri = req.uri();
+                if let Some(query) = uri.query() {
+                    Some(&query.to_owned());
+                }
+                None
+            };
+            let body = req.into_body();
+            let bytes = hyper::body::to_bytes(body).await?;
+            dbg!(&bytes); // this is correct by my accounts
+            let reader = &*bytes;
+            let original_request = UncheckedProposal::from_request(reader, query, headers).unwrap();
+
+            let proposal_psbt = scheduler.propose_payjoin(original_request).await.unwrap();
+
+            Ok(Response::new(Body::from(proposal_psbt)))
+        }
+
+        (&Method::POST, "/pj/schedule") => {
+            let bytes = hyper::body::to_bytes(req.into_body()).await?;
+            let request =
+                serde_json::from_slice::<ScheduledPayJoin>(&bytes).expect("invalid request");
+
+            let address = scheduler.schedule_payjoin(&request).await.unwrap();
+            let total_amount = request.total_amount();
+
+            // TODO: Don't hardcode pj endpoint
+            // * Optional cli flag or ENV for pj endpoint (in the case of port forwarding), otherwise
+            //      we should determine the bip21 string using `api::ServeOptions`
+            let uri = format!(
+                "bitcoin:{}?amount={}&pj=https://localhost:3010/pj",
+                address,
+                total_amount.to_string_in(bitcoin::Denomination::Bitcoin)
+            );
+            let mut response = Response::new(Body::from(uri));
+            response
+                .headers_mut()
+                .insert(hyper::header::CONTENT_TYPE, "text/plain".parse().unwrap());
+            Ok(response)
+        }
+
+        // Return the 404 Not Found for other routes.
+        _ => {
+            let mut not_found = Response::default();
+            *not_found.status_mut() = StatusCode::NOT_FOUND;
+            Ok(not_found)
+        }
+    }
+}
+
+pub(crate) struct Headers(hyper::HeaderMap);
+impl bip78::receiver::Headers for Headers {
+    fn get_header(&self, key: &str) -> Option<&str> { self.0.get(key)?.to_str().ok() }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,65 +1,18 @@
 mod args;
+mod http;
 mod lnd;
 pub mod scheduler;
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-
-use bip78::receiver::*;
-use bitcoin::{Address, Script, TxOut};
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Method, Request, Response, Server, StatusCode};
-use scheduler::ScheduledPayJoin;
+use scheduler::Scheduler;
 
 use crate::args::parse_args;
 use crate::lnd::*;
-use crate::scheduler::Scheduler;
 
 #[macro_use]
 extern crate serde_derive;
 extern crate configure_me;
 
 configure_me::include_config!();
-
-#[cfg(not(feature = "test_paths"))]
-const STATIC_DIR: &str = "/usr/share/loin/static";
-
-#[cfg(feature = "test_paths")]
-const STATIC_DIR: &str = "static";
-
-#[derive(Clone, Default)]
-struct PayJoins(Arc<Mutex<HashMap<Script, ScheduledPayJoin>>>);
-
-impl PayJoins {
-    fn insert(&self, address: &Address, payjoin: ScheduledPayJoin) -> Result<(), ()> {
-        use std::collections::hash_map::Entry;
-
-        match self.0.lock().expect("payjoins mutex poisoned").entry(address.script_pubkey()) {
-            Entry::Vacant(place) => {
-                place.insert(payjoin);
-                Ok(())
-            }
-            Entry::Occupied(_) => Err(()),
-        }
-    }
-
-    fn find<'a>(&self, txouts: &'a mut [TxOut]) -> Option<(&'a mut TxOut, ScheduledPayJoin)> {
-        let mut payjoins = self.0.lock().expect("payjoins mutex poisoned");
-        txouts
-            .iter_mut()
-            .find_map(|txout| payjoins.remove(&txout.script_pubkey).map(|payjoin| (txout, payjoin)))
-    }
-}
-
-#[derive(Clone)]
-struct Handler {
-    client: LndClient,
-    payjoins: PayJoins,
-}
-
-impl Handler {
-    async fn new(client: LndClient) -> Self { Self { client, payjoins: Default::default() } }
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -83,100 +36,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    let addr = ([127, 0, 0, 1], config.bind_port).into();
-
-    let service = make_service_fn(move |_| {
-        let sched = scheduler.clone(); // TODO Review this double clone. Wataf is going on here, are we referencing the same scheduler or do we need a container?
-        async move {
-            Ok::<_, hyper::Error>(service_fn(move |request| handle_web_req(sched.clone(), request)))
-        }
-    });
-
-    let server = Server::bind(&addr).serve(service);
-
-    println!("Listening on http://{}", addr);
-
-    server.await?;
+    let bind_addr = ([127, 0, 0, 1], config.bind_port).into();
+    http::serve(scheduler, bind_addr).await?;
 
     Ok(())
-}
-
-pub(crate) struct Headers(hyper::HeaderMap);
-impl bip78::receiver::Headers for Headers {
-    fn get_header(&self, key: &str) -> Option<&str> { self.0.get(key)?.to_str().ok() }
-}
-
-async fn handle_web_req(
-    scheduler: Scheduler,
-    req: Request<Body>,
-) -> Result<Response<Body>, hyper::Error> {
-    use std::path::Path;
-
-    match (req.method(), req.uri().path()) {
-        (&Method::GET, "/pj") => {
-            let index =
-                std::fs::read(Path::new(STATIC_DIR).join("index.html")).expect("can't open index");
-            Ok(Response::new(Body::from(index)))
-        }
-
-        (&Method::GET, path) if path.starts_with("/pj/static/") => {
-            let directory_traversal_vulnerable_path = &path[("/pj/static/".len())..];
-            let file =
-                std::fs::read(Path::new(STATIC_DIR).join(directory_traversal_vulnerable_path))
-                    .expect("can't open static file");
-            Ok(Response::new(Body::from(file)))
-        }
-
-        (&Method::POST, "/pj") => {
-            dbg!(req.uri().query());
-
-            let headers = Headers(req.headers().to_owned());
-            let query = {
-                let uri = req.uri();
-                if let Some(query) = uri.query() {
-                    Some(&query.to_owned());
-                }
-                None
-            };
-            let body = req.into_body();
-            let bytes = hyper::body::to_bytes(body).await?;
-            dbg!(&bytes); // this is correct by my accounts
-            let reader = &*bytes;
-            let original_request = UncheckedProposal::from_request(reader, query, headers).unwrap();
-
-            let proposal_psbt = scheduler.propose_payjoin(original_request).await.unwrap();
-
-            Ok(Response::new(Body::from(proposal_psbt)))
-        }
-
-        (&Method::POST, "/pj/schedule") => {
-            let bytes = hyper::body::to_bytes(req.into_body()).await?;
-            let request =
-                serde_json::from_slice::<ScheduledPayJoin>(&bytes).expect("invalid request");
-
-            let address = scheduler.schedule_payjoin(&request).await.unwrap();
-            let total_amount = request.total_amount();
-
-            // TODO: Don't hardcode pj endpoint
-            // * Optional cli flag or ENV for pj endpoint (in the case of port forwarding), otherwise
-            //      we should determine the bip21 string using `api::ServeOptions`
-            let uri = format!(
-                "bitcoin:{}?amount={}&pj=https://localhost:3010/pj",
-                address,
-                total_amount.to_string_in(bitcoin::Denomination::Bitcoin)
-            );
-            let mut response = Response::new(Body::from(uri));
-            response
-                .headers_mut()
-                .insert(hyper::header::CONTENT_TYPE, "text/plain".parse().unwrap());
-            Ok(response)
-        }
-
-        // Return the 404 Not Found for other routes.
-        _ => {
-            let mut not_found = Response::default();
-            *not_found.status_mut() = StatusCode::NOT_FOUND;
-            Ok(not_found)
-        }
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,14 @@ mod lnd;
 pub mod scheduler;
 
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
 
-use args::ArgError;
 use bip78::receiver::*;
 use bitcoin::util::address::Address;
 use bitcoin::util::psbt::PartiallySignedTransaction;
 use bitcoin::{Script, TxOut};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
-use ln_types::P2PAddress;
 use scheduler::ScheduledPayJoin;
 
 use crate::args::parse_args;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,7 +1,12 @@
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt;
+use std::sync::{Arc, Mutex};
 
-use bitcoin::TxOut;
+use bip78::receiver::{Proposal, UncheckedProposal};
+use bitcoin::consensus::Encodable;
+use bitcoin::psbt::PartiallySignedTransaction;
+use bitcoin::{Address, Script, TxOut};
 use ln_types::P2PAddress;
 use tonic_lnd::rpc::OpenChannelRequest;
 
@@ -29,12 +34,20 @@ impl ScheduledChannel {
 #[derive(Clone, serde_derive::Deserialize)]
 pub struct ScheduledPayJoin {
     #[serde(with = "bitcoin::util::amount::serde::as_sat")]
-    pub wallet_amount: bitcoin::Amount,
-    pub channels: Vec<ScheduledChannel>,
-    pub fee_rate: u64,
+    wallet_amount: bitcoin::Amount,
+    channels: Vec<ScheduledChannel>,
+    fee_rate: u64,
 }
 
 impl ScheduledPayJoin {
+    pub fn new(
+        wallet_amount: bitcoin::Amount,
+        channels: Vec<ScheduledChannel>,
+        fee_rate: u64,
+    ) -> Self {
+        Self { wallet_amount, channels, fee_rate }
+    }
+
     pub fn total_amount(&self) -> bitcoin::Amount {
         let fees = calculate_fees(
             self.channels.len() as u64,
@@ -50,15 +63,45 @@ impl ScheduledPayJoin {
             + fees
     }
 
+    /// Check that amounts make sense for original(ish) psbt.
+    /// We have to be paid what we're owed at a minimum.
+    pub fn is_paying_us_enough(&self, our_output: &TxOut) -> bool {
+        // TODO: replace with scheduled_payjoin.total_channel_amount()
+        let total_channel_amount: bitcoin::Amount = self
+            .channels
+            .iter()
+            .map(|channel| channel.amount)
+            .fold(bitcoin::Amount::ZERO, std::ops::Add::add);
+        // TODO: replace with sheduled_payjoin.fees()
+        let fees = calculate_fees(
+            self.channels.len() as u64,
+            self.fee_rate,
+            self.wallet_amount() != bitcoin::Amount::ZERO,
+        );
+        let wallet_amount = self.wallet_amount();
+
+        let owned_txout_value = our_output.value;
+
+        (total_channel_amount + fees + wallet_amount).as_sat() == owned_txout_value
+    }
+
+    /// This externally exposes [ScheduledPayJoin]::wallet_amount.
+    pub fn wallet_amount(&self) -> bitcoin::Amount { self.wallet_amount }
+
     /// Test connections with remote lightning nodes that we are trying to create channels with as
     /// part of this [ScheduledPayJoin].
-    pub async fn test_connections(&self, client: &LndClient) {
-        for channel in &self.channels {
-            client
-                .ensure_connected(channel.node.clone())
-                .await
-                .expect("connection should be successful");
+    pub async fn test_connections(&self, client: &LndClient) -> Result<(), LndError> {
+        let handles = self
+            .channels
+            .iter()
+            .map(|ch| (client.clone(), ch.node.clone()))
+            .map(|(client, node)| tokio::spawn(async move { client.ensure_connected(node).await }))
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.await.unwrap()?;
         }
+        Ok(())
     }
 
     pub async fn multi_open_channel(
@@ -141,11 +184,156 @@ impl ScheduledPayJoin {
             })
             .collect()
     }
+
+    // gen_funding_created AKA
+    fn add_channels_to_psbt<I>(
+        &self,
+        original_psbt: PartiallySignedTransaction,
+        owned_vout: usize,
+        funding_txos: I,
+    ) -> PartiallySignedTransaction
+    where
+        I: IntoIterator<Item = TxOut>,
+    {
+        let mut iter = funding_txos.into_iter();
+        let funding_txout = iter.next().unwrap(); // we assume there is at least 1.
+
+        let mut proposal_psbt = original_psbt.clone();
+        // determine whether we replace original psbt's owned output
+        // or whether we change the value to be wallet amount
+        if self.wallet_amount() == bitcoin::Amount::ZERO {
+            assert_eq!(funding_txout.value, self.channels[0].amount.as_sat());
+            proposal_psbt.unsigned_tx.output[owned_vout] = funding_txout;
+        } else {
+            proposal_psbt.unsigned_tx.output[owned_vout].value = self.wallet_amount().as_sat();
+            proposal_psbt.unsigned_tx.output.push(funding_txout)
+        }
+
+        // add remaining funding txouts
+        proposal_psbt.unsigned_tx.output.extend(iter);
+
+        // psbt should have outputs same length as contained unsigned tx
+        proposal_psbt.outputs.resize_with(proposal_psbt.unsigned_tx.output.len(), Default::default);
+
+        eprintln!("channel funding Proposal PSBT created: {:#?}", proposal_psbt);
+
+        proposal_psbt
+    }
 }
 
 pub type ChannelId = [u8; 32];
 
 fn temporary_channel_id() -> ChannelId { rand::random() }
+
+/// [Scheduler] lets you pre-batch PayJoins, usually containing Channel Opens.
+#[derive(Clone)]
+pub struct Scheduler {
+    lnd: LndClient,
+    pjs: Arc<Mutex<HashMap<Script, ScheduledPayJoin>>>, // payjoins mapped by owned `scriptPubKey`s
+}
+
+impl Scheduler {
+    /// New [Scheduler].
+    pub fn new(lnd: LndClient) -> Self { Self { lnd, pjs: Default::default() } }
+
+    /// Schedules a payjoin.
+    pub async fn schedule_payjoin(
+        &self,
+        pj: &ScheduledPayJoin,
+    ) -> Result<bitcoin::Address, SchedulerError> {
+        pj.test_connections(&self.lnd).await?;
+        let bitcoin_addr = self.lnd.get_new_bech32_address().await?;
+
+        if self.insert_payjoin(&bitcoin_addr, pj) {
+            Ok(bitcoin_addr)
+        } else {
+            Err(SchedulerError::Internal("lnd provided duplicate bitcoin addresses"))
+        }
+    }
+
+    /// Given an Original PSBT request, respond with a PayJoin Proposal,
+    /// returning a base64-encoded proposal PSBT (BIP-0078).
+    /// Check the receiver PayJoin checklist as per spec (https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#receivers-original-psbt-checklist)
+    pub async fn propose_payjoin(
+        &self,
+        original_req: UncheckedProposal,
+    ) -> Result<String, SchedulerError> {
+        if original_req.is_output_substitution_disabled() {
+            return Err(SchedulerError::OutputSubstitutionDisabled);
+        }
+        let request = original_req
+            // This is interactive, NOT a Payment Processor, so we don't save original tx.
+            // Humans can solve the failure case out of band by trying again.
+            .assume_interactive_receive_endpoint()
+            .assume_no_inputs_owned() // TODO Check
+            .assume_no_mixed_input_scripts() // This check is silly and could be ignored
+            .assume_no_inputs_seen_before(); // TODO
+
+        let mut original_psbt = request.psbt().clone();
+        eprintln!("Received psbt: {:#?}", original_psbt);
+
+        // prepare proposal psbt (psbt, owned_vout, ScheduledPayJoin)
+        let (owned_vout, pj) =
+            self.find_matching_payjoin(&original_psbt).ok_or(SchedulerError::NoMatchingPayJoin)?;
+
+        // FIXME does this need to go before find_matching_payjoin(...) ?
+        // empty signatures because we won't broadcast the original psbt
+        original_psbt
+            .unsigned_tx
+            .input
+            .iter_mut()
+            .for_each(|txin| txin.script_sig = bitcoin::Script::default());
+
+        let our_output = &original_psbt.unsigned_tx.output[owned_vout];
+        if !pj.is_paying_us_enough(our_output) {
+            return Err(SchedulerError::OriginalPsbtInvalidAmount);
+        }
+
+        // initiate multiple `open_channel` requests and return the vector:
+        // Vec<(temporary_channel_id:, funding_txout:)>
+        let open_chan_results = pj.multi_open_channel(&self.lnd).await?;
+        let funding_txouts = open_chan_results.iter().map(|(_, txo)| txo.clone());
+        let temporary_chan_ids = open_chan_results.iter().map(|(id, _)| *id);
+
+        // create and send `funding_created` to all responding lightning nodes
+        let proposal_psbt = pj.add_channels_to_psbt(original_psbt, owned_vout, funding_txouts);
+
+        let mut raw_psbt = Vec::new();
+        proposal_psbt.consensus_encode(&mut raw_psbt).unwrap();
+        self.lnd.verify_funding(&raw_psbt, temporary_chan_ids).await?;
+
+        // TODO explain why we're doing this superfluous bit or remove it
+        let proposal_psbt =
+            PartiallySignedTransaction::from_unsigned_tx(proposal_psbt.unsigned_tx.clone())
+                .expect("resetting tx failed");
+        eprintln!("Proposal PSBT that will be returned: {:#?}", proposal_psbt);
+
+        let mut psbt_bytes = Vec::new();
+        proposal_psbt.consensus_encode(&mut psbt_bytes).unwrap();
+        Ok(base64::encode(&mut psbt_bytes))
+    }
+
+    /// Insert payjoin associated with bitcoin address.
+    fn insert_payjoin(&self, bitcoin_addr: &Address, pj: &ScheduledPayJoin) -> bool {
+        let mut pj_by_spk = self.pjs.lock().unwrap();
+        pj_by_spk.insert(bitcoin_addr.script_pubkey(), pj.clone()).is_none()
+    }
+
+    /// Get a prepared [ScheduledPayJoin] matching a PayJoin Request's Original PSBT
+    fn find_matching_payjoin(
+        &self,
+        psbt: &PartiallySignedTransaction,
+    ) -> Option<(usize, ScheduledPayJoin)> {
+        let mut pj_by_script = self.pjs.lock().unwrap();
+
+        // find vout of owned output, pop scheduled psbt
+        let vout_pj_match = psbt.unsigned_tx.output.iter().enumerate().find_map(|(vout, txout)| {
+            pj_by_script.remove(&txout.script_pubkey).map(|pj| (vout, pj))
+        });
+
+        vout_pj_match
+    }
+}
 
 pub fn calculate_fees(
     channel_count: u64,
@@ -164,8 +352,16 @@ pub fn calculate_fees(
 #[derive(Debug)]
 pub enum SchedulerError {
     Lnd(LndError),
-    /// Failed to open any channel for [ScheduledPayJoin].
+    /// Internal error that should not be shared
+    Internal(&'static str),
+    /// Output Substitution is required to change the original output to a channel open
+    OutputSubstitutionDisabled,
+    /// No Original Psbt outputs match any [ScheduledPayJoin]
+    NoMatchingPayJoin,
+    /// Failed to open any channel for [ScheduledPayJoin]
     PayJoinCannotOpenAnyChannel,
+    /// Original Psbt does not respect requested amount
+    OriginalPsbtInvalidAmount,
 }
 
 impl fmt::Display for SchedulerError {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,0 +1,159 @@
+use std::convert::TryInto;
+
+use bitcoin::TxOut;
+use ln_types::P2PAddress;
+use tonic_lnd::rpc::OpenChannelRequest;
+
+use crate::args::ArgError;
+use crate::lnd::LndClient;
+
+#[derive(Clone, serde_derive::Deserialize)]
+pub struct ScheduledChannel {
+    pub(crate) node: P2PAddress,
+    #[serde(with = "bitcoin::util::amount::serde::as_sat")]
+    pub(crate) amount: bitcoin::Amount,
+}
+
+impl ScheduledChannel {
+    pub(crate) fn from_args(addr: &str, amount: &str) -> Result<Self, ArgError> {
+        let node = addr.parse::<P2PAddress>().map_err(ArgError::InvalidNodeAddress)?;
+
+        let amount = bitcoin::Amount::from_str_in(amount, bitcoin::Denomination::Satoshi)
+            .map_err(ArgError::InvalidBitcoinAmount)?;
+
+        Ok(Self { node, amount })
+    }
+}
+
+#[derive(Clone, serde_derive::Deserialize)]
+pub struct ScheduledPayJoin {
+    #[serde(with = "bitcoin::util::amount::serde::as_sat")]
+    pub wallet_amount: bitcoin::Amount,
+    pub channels: Vec<ScheduledChannel>,
+    pub fee_rate: u64,
+}
+
+impl ScheduledPayJoin {
+    pub fn total_amount(&self) -> bitcoin::Amount {
+        let fees = calculate_fees(
+            self.channels.len() as u64,
+            self.fee_rate,
+            self.wallet_amount != bitcoin::Amount::ZERO,
+        );
+
+        self.channels
+            .iter()
+            .map(|channel| channel.amount)
+            .fold(bitcoin::Amount::ZERO, std::ops::Add::add)
+            + self.wallet_amount
+            + fees
+    }
+
+    /// Test connections with remote lightning nodes that we are trying to create channels with as
+    /// part of this [ScheduledPayJoin].
+    pub async fn test_connections(&self, client: &LndClient) {
+        for channel in &self.channels {
+            client
+                .ensure_connected(channel.node.clone())
+                .await
+                .expect("connection should be successful");
+        }
+    }
+
+    pub async fn multi_open_channel(&self, lnd: &LndClient) -> Result<Vec<(ChannelId, TxOut)>, ()> {
+        let requests = self.generate_open_channel_requests();
+
+        let handles = requests
+            .iter()
+            .cloned()
+            .map(|(node, chan_id, req)| {
+                let lnd = lnd.clone();
+                let handle = tokio::spawn(async move {
+                    lnd.ensure_connected(node).await.unwrap(); // TODO return LndErrors
+                    let funding_txout = lnd
+                        .open_channel(req)
+                        .await
+                        .unwrap()
+                        .map(|psbt| psbt.unsigned_tx.output[0].clone());
+                    Ok(funding_txout)
+                });
+                (chan_id, handle)
+            })
+            .collect::<Vec<_>>();
+
+        let mut funding_txos = Vec::<(ChannelId, TxOut)>::with_capacity(handles.len());
+        for (chan_id, handle) in handles {
+            match handle.await.unwrap()? {
+                    Some(vout) => funding_txos.push((chan_id, vout)),
+                    None => eprintln!("failed to receive funding psbt after channel open request. !this case is not handled!"),
+                };
+        }
+
+        if funding_txos.is_empty() {
+            // TODO return LndError
+            panic!("PayJoin cannot open any channel");
+        } else {
+            Ok(funding_txos)
+        }
+    }
+
+    pub fn generate_open_channel_requests(
+        &self,
+    ) -> Vec<(P2PAddress, ChannelId, OpenChannelRequest)> {
+        self.channels
+            .iter()
+            .map(|chan| {
+                let node_addr = chan.node.clone();
+                let chan_id = temporary_channel_id();
+
+                let psbt_shim = tonic_lnd::rpc::PsbtShim {
+                    pending_chan_id: chan_id.into(),
+                    base_psbt: Vec::new(),
+                    no_publish: true,
+                };
+                let funding_shim = tonic_lnd::rpc::funding_shim::Shim::PsbtShim(psbt_shim);
+                let funding_shim = tonic_lnd::rpc::FundingShim { shim: Some(funding_shim) };
+
+                let req = OpenChannelRequest {
+                    node_pubkey: chan.node.node_id.to_vec(),
+                    local_funding_amount: chan
+                        .amount
+                        .as_sat()
+                        .try_into()
+                        .expect("amount too large"),
+                    push_sat: 0,
+                    private: false,
+                    min_htlc_msat: 0,
+                    remote_csv_delay: 0,
+                    spend_unconfirmed: false,
+                    close_address: String::new(),
+                    funding_shim: Some(funding_shim),
+                    remote_max_value_in_flight_msat: chan.amount.as_sat() * 1000,
+                    remote_max_htlcs: 10,
+                    max_local_csv: 288,
+                    ..Default::default()
+                };
+
+                (node_addr, chan_id, req)
+            })
+            .collect()
+    }
+}
+
+pub type ChannelId = [u8; 32];
+
+fn temporary_channel_id() -> ChannelId { rand::random() }
+
+pub fn calculate_fees(
+    channel_count: u64,
+    fee_rate: u64,
+    has_additional_output: bool,
+) -> bitcoin::Amount {
+    let additional_vsize = if has_additional_output {
+        channel_count * (8 + 1 + 1 + 32)
+    } else {
+        (channel_count - 1) * (8 + 1 + 1 + 32) + 12
+    };
+
+    bitcoin::Amount::from_sat(fee_rate * additional_vsize)
+}


### PR DESCRIPTION
1st commit: split rpc request creation from the now-async call. Integration Tested ✅

this PR splits scheduler and http as mods so that main is much more manageable