### PR TITLE
Bump payjoin crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 [[package]]
 name = "bip78"
 version = "0.2.0-preview"
-source = "git+https://github.com/dangould/rust-payjoin?branch=receive-logic-v3#ff17f1b3619eaba19c847af39bfb6b17c6c2c259"
+source = "git+https://github.com/dangould/rust-payjoin?rev=8d9b7d6#8d9b7d6ee5907b068a54bf65fd6ad5744c402756"
 dependencies = [
  "base64",
  "bip21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ test_paths = []
 
 [dependencies]
 bitcoin = { version = "0.28.1", features = ["use-serde"] }
-bip78 = { git = "https://github.com/dangould/rust-payjoin", branch = "receive-logic-v3", features = ["sender", "receiver" ] }
+bip78 = { git = "https://github.com/dangould/rust-payjoin", rev = "8d9b7d6", features = ["sender", "receiver" ] }
 url = "2.2.2"
 hyper = "0.14.9"
 tonic_lnd = "0.4.0"


### PR DESCRIPTION
The old version failed on valid 'Content-Type: text/plain; charset=utf8' because /pj POST requests expected only the MIME type and nothing thereafter

still receive-logic-v3 branch but the head was cached from cargo so I specified the rev